### PR TITLE
New feaure HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializationFeature.java
@@ -420,6 +420,15 @@ public enum SerializationFeature implements ConfigFeature
      * @since 2.3
      */
     USE_EQUALITY_FOR_OBJECT_ID(false)
+    ,
+
+    /**
+     * Feature that determines if serialization avoiding circular dependencies
+     * (i.e. remembering visited elements and fully serializing only the first)
+     * should be applied to arrays as a whole, or should treat individually each
+     * item, "wiping the memory" for visited elements in every iteration.
+     */
+    HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS(false)
     ;
 
     private final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/SerializerProvider.java
@@ -1438,4 +1438,11 @@ public abstract class SerializerProvider
         */
         return df;
     }
+
+    /**
+     * This method wipes out from memory
+     */
+    public void resetMemoryCircularReference() {
+        // unimplemented method
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/DefaultSerializerProvider.java
@@ -615,6 +615,13 @@ filter.getClass().getName(), t.getClass().getName(), t.getMessage());
         }
 
         @Override
+        public void resetMemoryCircularReference() {
+            if(_seenObjectIds != null) {
+                _seenObjectIds.clear();
+            }
+        }
+
+        @Override
         public DefaultSerializerProvider copy()
         {
             if (getClass() != Impl.class) {

--- a/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/ser/std/CollectionSerializer.java
@@ -50,13 +50,13 @@ public class CollectionSerializer
         // note: assumption is 'property' is always passed as null
         this(elemType, staticTyping, vts, valueSerializer);
     }
-    
+
     public CollectionSerializer(CollectionSerializer src,
             BeanProperty property, TypeSerializer vts, JsonSerializer<?> valueSerializer,
             Boolean unwrapSingle) {
         super(src, property, vts, valueSerializer, unwrapSingle);
     }
-    
+
     @Override
     public ContainerSerializer<?> _withValueTypeSerializer(TypeSerializer vts) {
         return new CollectionSerializer(this, _property, vts, _elementSerializer, _unwrapSingle);
@@ -107,7 +107,7 @@ public class CollectionSerializer
         serializeContents(value, g, provider);
         g.writeEndArray();
     }
-    
+
     @Override
     public void serializeContents(Collection<?> value, JsonGenerator g, SerializerProvider provider) throws IOException
     {
@@ -123,10 +123,17 @@ public class CollectionSerializer
         PropertySerializerMap serializers = _dynamicSerializers;
         final TypeSerializer typeSer = _valueTypeSerializer;
 
+        final boolean handleCircularReferencesIndividually = provider.isEnabled(
+            SerializationFeature.HANDLE_CIRCULAR_REFERENCE_INDIVIDUALLY_FOR_ARRAYS
+        );
+
         int i = 0;
         try {
             do {
                 Object elem = it.next();
+                if(handleCircularReferencesIndividually) {
+                    provider.resetMemoryCircularReference();
+                }
                 if (elem == null) {
                     provider.defaultSerializeNull(g);
                 } else {


### PR DESCRIPTION

Added a new feature to handle circular references independently for every item of a collection, in order to fully serialize entities, but still avoiding circular dependencies in depth, for each item individually.